### PR TITLE
Update testing and source generation packages to latest version

### DIFF
--- a/DecoratorGenerator.UnitTests/CSharpSourceGeneratorVerifier.cs
+++ b/DecoratorGenerator.UnitTests/CSharpSourceGeneratorVerifier.cs
@@ -1,21 +1,19 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 using System.Collections.Immutable;
 
 namespace DecoratorGenerator.UnitTests;
 
 public static class CSharpSourceGeneratorVerifier<TSourceGenerator> where TSourceGenerator : ISourceGenerator, new()
 {
-    public class Test : CSharpSourceGeneratorTest<TSourceGenerator, NUnitVerifier>
+    public class Test : CSharpSourceGeneratorTest<TSourceGenerator, DefaultVerifier>
     {
-        public Test()
-        {
+        public Test() {
         }
 
-        protected override CompilationOptions CreateCompilationOptions()
-        {
+        protected override CompilationOptions CreateCompilationOptions() {
             var compilationOptions = base.CreateCompilationOptions();
             return compilationOptions.WithSpecificDiagnosticOptions(
                  compilationOptions.SpecificDiagnosticOptions.SetItems(GetNullableWarningsFromCompiler()));
@@ -23,8 +21,7 @@ public static class CSharpSourceGeneratorVerifier<TSourceGenerator> where TSourc
 
         public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.Default;
 
-        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
-        {
+        private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler() {
             string[] args = { "/warnaserror:nullable" };
             var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
             var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
@@ -32,8 +29,7 @@ public static class CSharpSourceGeneratorVerifier<TSourceGenerator> where TSourc
             return nullableWarnings;
         }
 
-        protected override ParseOptions CreateParseOptions()
-        {
+        protected override ParseOptions CreateParseOptions() {
             return ((CSharpParseOptions)base.CreateParseOptions()).WithLanguageVersion(LanguageVersion);
         }
     }

--- a/DecoratorGenerator.UnitTests/DecoratorGenerator.UnitTests.csproj
+++ b/DecoratorGenerator.UnitTests/DecoratorGenerator.UnitTests.csproj
@@ -11,17 +11,20 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.103.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DecoratorGenerator/DecoratorGenerator.csproj
+++ b/DecoratorGenerator/DecoratorGenerator.csproj
@@ -53,8 +53,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Use DefaultVerifier instead of NUnitVerifier in unit tests as suggested (https://github.com/dotnet/roslyn-sdk/issues/1127#issuecomment-2057446130) to fix issues when upgrading to NUnit 4.
- Upgrade to Nunit 4 and upgrade source generation nuget packages to latest stable versions.